### PR TITLE
Make the details of an XML-RPC error accessible.

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,26 @@
+package xmlrpc
+
+import (
+	"fmt"
+)
+
+// Error represents errors returned on xmlrpc request.
+type Error struct {
+	code    string
+	message string
+}
+
+// Error() method implements Error interface
+func (e *Error) Error() string {
+	return fmt.Sprintf("Error: \"%s\" Code: %s", e.message, e.code)
+}
+
+// Code ...
+func (e *Error) Code() string {
+	return e.code
+}
+
+// Message ...
+func (e *Error) Message() string {
+	return e.message
+}

--- a/response.go
+++ b/response.go
@@ -34,7 +34,7 @@ func parseFailedResponse(response []byte) (err error) {
 		return err
 	}
 
-	return &(xmlrpcError{
+	return &(Error{
 		code:    fmt.Sprintf("%v", faultDetails["faultCode"]),
 		message: faultDetails["faultString"].(string),
 	})

--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -1,9 +1,5 @@
 package xmlrpc
 
-import (
-	"fmt"
-)
-
 // Struct presents hash type used in xmlprc requests and responses.
 type Struct map[string]interface{}
 
@@ -13,15 +9,4 @@ type Base64 string
 // Params represents a list of parameters to a method.
 type Params struct {
 	Params []interface{}
-}
-
-// xmlrpcError represents errors returned on xmlrpc request.
-type xmlrpcError struct {
-	code    string
-	message string
-}
-
-// Error() method implements Error interface
-func (e *xmlrpcError) Error() string {
-	return fmt.Sprintf("Error: \"%s\" Code: %s", e.message, e.code)
 }


### PR DESCRIPTION
This introduces an exported Error type that represents an XML-RPC error.

The calling code can try to cast the returned error to this type. If the
cast is successful, it knows that the API call happened and an XML-RPC
error was the response of the call. The Error type has getters for the
XML-RPC error code and description.

Author: @amfranz